### PR TITLE
update: jQuery を削除

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -69,22 +69,6 @@
   <link rel="stylesheet" href="/css/main.css" />
 
   <!-- JS Framework -------------------------- -->
-  <!-- JQuery https://releases.jquery.com/ -->
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
-  <!-- <script>
-      $(function () {
-          var headerHight = 500;
-          $('a[href^="#"]').click(function () {
-              var href = $(this).attr("href");
-              var target = $(href == "#" || href == "" ? "html" : href);
-              var position = target.offset().top - headerHight;
-              console.log("click:" + target);
-              $("html, body").animate({ scrollTop: position }, 1000, "swing");
-              return false;
-          });
-      });
-  </script>
--->
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,34 +14,5 @@
 
     <div id="page-top"><a href="#top"><img src="/img/svg/up.svg" alt="Up" width="24px" /></a></div>
     {% include footer.html %}
-
-    <script>
-      window.onload = function() {
-        var agent = window.navigator.userAgent.toLowerCase();
-        var ie11 = (agent.indexOf('trident/7') !== -1);
-        if(ie11){
-          var spimg = document.getElementsByClassName("sponsors-rank-img");
-          for(var i = 0; i < spimg.length; i++) {
-            spimg[i].style.height    = "auto";
-            spimg[i].style.maxHeight = "none";
-          }
-        }
-        var btn = $('#page-top');
-        //スクロールしてページトップから100に達したらボタンを表示
-        $(window).on('load scroll', function(){
-          if($(this).scrollTop() > 100) {
-            btn.addClass('active');
-          }else{
-            btn.removeClass('active');
-          }
-        });
-
-        $('.navbar-nav > a , .dropdown-menu>a').on('click', function(){
-          if(this.id != 'navbarDropdown'){
-            $('.navbar-collapse').collapse('hide');
-          }
-        });
-      }
-      </script>
-    </body>
+  </body>
 </html>


### PR DESCRIPTION
# 概要

- 2024年版の実装に含まれていた、古い jQuery のコードを削除しました
- jQuery の利用場所が 0 になったため、<head> 内での jQuery 読み込みも削除

# jQuery の利用箇所（対応する HTML 要素が無い部分もあるため推測も含む）
- スクロール位置によって、「ページトップへジャンプ」ボタンの出し分け
- navbar のメニュー制御
- ページ内スクロールのスムーススクロール化（ただし、コメントアウトしてあった）