### PR TITLE
fix: hero image 直下の説明文の style 崩れを修正

### DIFF
--- a/_includes/top/sections/hero.html
+++ b/_includes/top/sections/hero.html
@@ -2,7 +2,7 @@
   <img src="/img/2025/top/hero-image.png" alt="好奇心に火をつけよう！！ Inspire Next" />
 </div>
 
-<div class="flex mx-auto max-w-[1020px] justify-center lg:justify-start">
+<div class="flex mx-auto max-w-[1080px] justify-center lg:justify-start">
   <p class="lg:-mt-6 xl:-mt-10 leading-8 px-6 text-lg font-bold">
     DojoCon Japanとは日本の CoderDojo コミュニティメンバーが全国から集まる、<br />
     年に1度のカンファレンスイベント(CoderDojo Conference) です。<br />

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: top
 ---
-<div class="bg-white bg-[url(/img/2025/top/header-background.png)] bg-contain bg-no-repeat bg-top bg-center rounded-2xl min-h-full flex-grow flex flex-col">
+<div class="bg-[url(/img/2025/top/header-background.png)] bg-contain bg-no-repeat bg-top bg-center">
   {% include header.html %}
 
   {% include top/sections/hero.html %}


### PR DESCRIPTION
## 概要

- hero image 直下の説明文（「DojoCon Japanとは～」）の style 崩れを修正
- 不要な class 指定がいくつかあったため削除
  - 不要な `flex` 指定など
  - 別の実装方針で進めていた際の class 指定が残ってしまっていた :pray:

## 比較
| Before| After |
|--------|--------|
| <img width="2332" height="2248" alt="localhost_4000_ (1)" src="https://github.com/user-attachments/assets/c5bc4427-532d-433f-a669-c9f30995d562" /> | <img width="2332" height="2248" alt="localhost_4000_" src="https://github.com/user-attachments/assets/5c17dfbe-959e-4e5d-91ea-c6c7b59c0422" /> | 