### PR TITLE
TOPで画面幅が小さいときに使うプルダウン式のナビバーの実装

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,50 @@
-<h1 class="max-w-lg mx-auto pt-5 px-8">
+<h1 class="hidden xl:block max-w-lg mx-auto pt-5 px-8">
   <a href="/">
     <img src="/img/common/header-logo.webp" alt="DojoCon Japan 2025 Inspire Next." />
   </a>
 </h1>
+
+<div class="xl:hidden fixed top-9 left-0 min-h-18 w-screen flex justify-center z-10">
+  <div class="flex h-full flex-col w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-4 py-2 inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)] shadow-[7px_7px_10px_rgba(125,125,125,0.15)]">
+    <div class="flex justify-between items-center">
+      <a href="/" class="flex items-center h-full">
+        <img src="/img/common/header-logo.webp" class="max-h-full max-w-[250px] h-auto" alt="DojoCon Japan 2025 Inspire Next." />
+      </a>
+      <button id="menu-btn" type="button" aria-label="メニューを開く" class="w-12 h-9 flex flex-col justify-center items-center shrink-0 rounded cursor-pointer border border-gray-300 bg-white">
+        <span class="block w-8 h-0.5 bg-gray-400 mb-1.5 rounded"></span>
+        <span class="block w-8 h-0.5 bg-gray-400 mb-1.5 rounded"></span>
+        <span class="block w-8 h-0.5 bg-gray-400 rounded"></span>
+      </button>
+    </div>
+    <nav id="menu-nav" class="hidden flex-col items-stretch transition-all duration-300 my-2">
+      <ul class="flex flex-col min-h-20 items-stretch gap-2 *:leading-[1.75] *:text-[#cc8f2e] *:text-center *:text-[20px] *:px-6">
+        <li><a href="#outline">開催概要</a></li>
+        <li><a href="#session">セッション</a></li>
+        <li><a href="/events">企画</a></li>
+        <li><a href="/contest">コンテスト</a></li>
+        <li><a href="https://suzuri.jp/DojoConJapan" target="_blank">グッズ</a></li>
+        <li><a href="/sponsorship">スポンサー募集</a></li>
+        <li><a href="{{ site.contact }}" target="_blank">お問い合わせ</a></li>
+      </ul>
+    </nav>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const menuBtn = document.getElementById('menu-btn');
+  const menuNav = document.getElementById('menu-nav');
+  if (!menuBtn || !menuNav) return;
+
+  menuBtn.addEventListener('click', function() {
+    menuNav.classList.toggle('flex');
+    menuNav.classList.toggle('hidden');
+  });
+  menuNav.querySelectorAll('a').forEach(function(link) {
+    link.addEventListener('click', function() {
+      menuNav.classList.remove('flex');
+      menuNav.classList.add('hidden');
+    });
+  });
+});
+</script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,10 +13,8 @@
           alt="DojoCon Japan 2025 Inspire Next." />
       </a>
       <button id="menu-btn" type="button" aria-label="メニューを開く"
-        class="flex h-9 w-12 shrink-0 flex-col items-center justify-center rounded border border-gray-300 bg-white cursor-pointer">
-        <span class="block w-8 h-0.5 mb-1.5 rounded bg-gray-400"></span>
-        <span class="block w-8 h-0.5 mb-1.5 rounded bg-gray-400"></span>
-        <span class="block w-8 h-0.5 rounded bg-gray-400"></span>
+        class="flex p-2 shrink-0 flex-col items-center justify-center rounded border border-gray-300 bg-white cursor-pointer">
+        <i class="fa-solid fa-bars"></i>
       </button>
     </div>
     <nav id="menu-nav" class="hidden my-2 flex-col items-stretch transition-all duration-300">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,23 +1,27 @@
-<h1 class="hidden xl:block max-w-lg mx-auto pt-5 px-8">
+<h1 class="xl:block hidden mx-auto max-w-lg pt-5 px-8">
   <a href="/">
     <img src="/img/common/header-logo.webp" alt="DojoCon Japan 2025 Inspire Next." />
   </a>
 </h1>
 
-<div class="xl:hidden fixed top-9 left-0 min-h-18 w-screen flex justify-center z-10">
-  <div class="flex h-full flex-col w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-4 py-2 inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)] shadow-[7px_7px_10px_rgba(125,125,125,0.15)]">
-    <div class="flex justify-between items-center gap-2">
-      <a href="/" class="flex items-center h-full">
-        <img src="/img/common/header-logo.webp" class="max-h-full max-w-[250px] w-full" alt="DojoCon Japan 2025 Inspire Next." />
+<div class="fixed xl:hidden left-0 top-9 z-10 flex w-screen min-h-18 justify-center">
+  <div
+    class="flex flex-col h-full w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-4 py-2 shadow-[7px_7px_10px_rgba(125,125,125,0.15)] inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)]">
+    <div class="flex items-center justify-between gap-2">
+      <a href="/" class="flex h-full items-center">
+        <img src="/img/common/header-logo.webp" class="w-full max-w-[250px] max-h-full"
+          alt="DojoCon Japan 2025 Inspire Next." />
       </a>
-      <button id="menu-btn" type="button" aria-label="メニューを開く" class="w-12 h-9 flex flex-col justify-center items-center shrink-0 rounded cursor-pointer border border-gray-300 bg-white">
-        <span class="block w-8 h-0.5 bg-gray-400 mb-1.5 rounded"></span>
-        <span class="block w-8 h-0.5 bg-gray-400 mb-1.5 rounded"></span>
-        <span class="block w-8 h-0.5 bg-gray-400 rounded"></span>
+      <button id="menu-btn" type="button" aria-label="メニューを開く"
+        class="flex h-9 w-12 shrink-0 flex-col items-center justify-center rounded border border-gray-300 bg-white cursor-pointer">
+        <span class="block w-8 h-0.5 mb-1.5 rounded bg-gray-400"></span>
+        <span class="block w-8 h-0.5 mb-1.5 rounded bg-gray-400"></span>
+        <span class="block w-8 h-0.5 rounded bg-gray-400"></span>
       </button>
     </div>
-    <nav id="menu-nav" class="hidden flex-col items-stretch transition-all duration-300 my-2">
-      <ul class="flex flex-col min-h-20 items-stretch gap-2 *:leading-[1.75] *:text-[#cc8f2e] *:text-center *:text-[20px] *:px-6">
+    <nav id="menu-nav" class="hidden my-2 flex-col items-stretch transition-all duration-300">
+      <ul
+        class="flex flex-col min-h-20 items-stretch gap-2 *:px-6 *:text-center *:text-[20px] *:leading-[1.75] *:text-[#cc8f2e]">
         <li><a href="#outline">開催概要</a></li>
         <li><a href="#session">セッション</a></li>
         <li><a href="/events">企画</a></li>
@@ -31,20 +35,20 @@
 </div>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-  const menuBtn = document.getElementById('menu-btn');
-  const menuNav = document.getElementById('menu-nav');
-  if (!menuBtn || !menuNav) return;
+  document.addEventListener('DOMContentLoaded', function () {
+    const menuBtn = document.getElementById('menu-btn');
+    const menuNav = document.getElementById('menu-nav');
+    if (!menuBtn || !menuNav) return;
 
-  menuBtn.addEventListener('click', function() {
-    menuNav.classList.toggle('flex');
-    menuNav.classList.toggle('hidden');
-  });
-  menuNav.querySelectorAll('a').forEach(function(link) {
-    link.addEventListener('click', function() {
-      menuNav.classList.remove('flex');
-      menuNav.classList.add('hidden');
+    menuBtn.addEventListener('click', function () {
+      menuNav.classList.toggle('flex');
+      menuNav.classList.toggle('hidden');
+    });
+    menuNav.querySelectorAll('a').forEach(function (link) {
+      link.addEventListener('click', function () {
+        menuNav.classList.remove('flex');
+        menuNav.classList.add('hidden');
+      });
     });
   });
-});
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,9 +6,9 @@
 
 <div class="xl:hidden fixed top-9 left-0 min-h-18 w-screen flex justify-center z-10">
   <div class="flex h-full flex-col w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-4 py-2 inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)] shadow-[7px_7px_10px_rgba(125,125,125,0.15)]">
-    <div class="flex justify-between items-center">
+    <div class="flex justify-between items-center gap-2">
       <a href="/" class="flex items-center h-full">
-        <img src="/img/common/header-logo.webp" class="max-h-full max-w-[250px] h-auto" alt="DojoCon Japan 2025 Inspire Next." />
+        <img src="/img/common/header-logo.webp" class="max-h-full max-w-[250px] w-full" alt="DojoCon Japan 2025 Inspire Next." />
       </a>
       <button id="menu-btn" type="button" aria-label="メニューを開く" class="w-12 h-9 flex flex-col justify-center items-center shrink-0 rounded cursor-pointer border border-gray-300 bg-white">
         <span class="block w-8 h-0.5 bg-gray-400 mb-1.5 rounded"></span>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
 
 <div class="fixed xl:hidden left-0 top-7 z-10 flex w-screen min-h-18 justify-center">
   <div
-    class="flex flex-col h-full w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-5 py-3 shadow-[7px_7px_10px_rgba(125,125,125,0.15)] inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)]">
+    class="flex flex-col h-full w-[calc(100%-60px)] items-stretch rounded-[10px] bg-[#f5f5f5] px-5 py-3 shadow-[7px_7px_10px_rgba(125,125,125,0.15)] inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)]">
     <div class="flex items-center justify-between gap-2">
       <a href="/" class="flex h-full items-center">
         <img src="/img/common/header-logo.webp" class="w-full max-w-[250px] max-h-full"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,9 +4,9 @@
   </a>
 </h1>
 
-<div class="fixed xl:hidden left-0 top-9 z-10 flex w-screen min-h-18 justify-center">
+<div class="fixed xl:hidden left-0 top-7 z-10 flex w-screen min-h-18 justify-center">
   <div
-    class="flex flex-col h-full w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-4 py-2 shadow-[7px_7px_10px_rgba(125,125,125,0.15)] inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)]">
+    class="flex flex-col h-full w-[calc(100%-max(10%,32px))] items-stretch rounded-[10px] bg-[#f5f5f5] px-5 py-3 shadow-[7px_7px_10px_rgba(125,125,125,0.15)] inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)]">
     <div class="flex items-center justify-between gap-2">
       <a href="/" class="flex h-full items-center">
         <img src="/img/common/header-logo.webp" class="w-full max-w-[250px] max-h-full"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,7 @@
     </div>
     <nav id="menu-nav" class="hidden my-2 flex-col items-stretch transition-all duration-300">
       <ul
-        class="flex flex-col min-h-20 items-stretch gap-2 *:px-6 *:text-center *:text-[20px] *:leading-[1.75] *:text-[#cc8f2e]">
+        class="flex flex-col min-h-20 items-stretch gap-2 *:px-6 *:text-center *:text-[20px] *:leading-[1.75] *:text-[#cc8f2e] [&_a]:block">
         <li><a href="#outline">開催概要</a></li>
         <li><a href="#session">セッション</a></li>
         <li><a href="/events">企画</a></li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,4 +1,4 @@
-<div class="mx-4 sticky top-4 z-10">
+<div class="hidden xl:block sticky mx-4 top-4 z-10">
   <nav
     class="rounded-[40px] w-fit mx-auto bg-[#f5f5f5] mt-8 inset-shadow-[0px_-2px_10px_rgba(125,125,125,0.25)] shadow-[7px_7px_10px_rgba(125,125,125,0.15)]">
     <ul class="flex flex-wrap min-h-20 items-center p-5 justify-center divide-x-2 gap-y-2 *:text-[#cc8f2e] *:px-6">

--- a/_includes/top/sections/hero.html
+++ b/_includes/top/sections/hero.html
@@ -1,4 +1,4 @@
-<div class="max-w-[1500px] mt-2 xl:-mt-14 mx-auto px-[2%] md:px-8">
+<div class="max-w-[1500px] mt-25 xl:-mt-14 mx-auto px-[2%] md:px-8 ">
   <img src="/img/top/hero-image.webp" alt="好奇心に火をつけよう！！ Inspire Next" />
 </div>
 

--- a/_includes/top/sections/outline.html
+++ b/_includes/top/sections/outline.html
@@ -1,4 +1,4 @@
-<h2 id="outline" class="text-4xl text-center mb-8 pt-20">
+<h2 id="outline" class="text-4xl text-center mb-8 pt-28 -mt-8">
   開催概要
   <span class="block mt-5 text-2xl">OUTLINE</span>
 </h2>

--- a/_includes/top/sections/session.html
+++ b/_includes/top/sections/session.html
@@ -1,4 +1,4 @@
-<div id="session" class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto mt-8 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
+<div id="session" class="max-w-3xl lg:max-w-[1800px] pt-28 pb-8 mx-auto -mt-12 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
   <div class="w-full lg:w-2/5 mb-8 lg:mt-68">
     <div class="lg:max-w-sm lg:place-self-end lg:mr-[10%]">
       <h2 class="text-4xl mb-4 text-center lg:text-left">


### PR DESCRIPTION
- **TOPで画面幅が狭い場合に使うnavbarを実装**
- **ankerlinkのスクロール位置を調整**
- **ロゴを横幅に合わせて伸縮するように修正**
- **refactor クラスを書く順序を整理**

ナビバーが改行されるとankerlinkのスクロール位置を固定できないため
改行が起こる前に横幅1280px以下ではプルダウン式のナビバーが表示されるようにしました。

また、ankerlink先の要素にスクロール先でナビバーがぶつからないようにするために
padding-topと相殺用のmargin-top(負)を追加しています。

<img width="376" height="332" alt="image" src="https://github.com/user-attachments/assets/f8a47a6e-a54c-4047-8df9-c8c457096da1" />
