### PR TITLE
セッション欄の横幅がSP表示で崩れる問題を修正

### DIFF
--- a/_includes/top/sections/session.html
+++ b/_includes/top/sections/session.html
@@ -1,4 +1,4 @@
-<div id="session" class="max-w-3xl lg:max-w-[1800px] pt-28 pb-8 mx-auto -mt-12 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
+<div id="session" class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto pt-28 -mt-28 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
   <div class="w-full lg:w-2/5 mb-8 lg:mt-68">
     <div class="lg:max-w-sm lg:place-self-end lg:mr-[10%]">
       <h2 class="text-4xl mb-4 text-center lg:text-left">


### PR DESCRIPTION
掲題のとおりです
<img width="471" height="744" alt="image" src="https://github.com/user-attachments/assets/99a7f02d-2c35-4870-9fb9-28caabca8218" />
