### PR TITLE
1280px周辺でお知らせ欄と直上の文章がぶつかる問題を修正

### DIFF
--- a/_includes/top/sections/news.html
+++ b/_includes/top/sections/news.html
@@ -1,4 +1,4 @@
-<h2 class="text-4xl mt-20 sm:mt-32 text-center">
+<h2 class="text-4xl mt-20 sm:mt-40 text-center">
   お知らせ
   <span class="block mt-5 text-2xl">NEWS</span>
 </h2>


### PR DESCRIPTION
文言が増えたことでお知らせ欄と直上の説明がスタイルが変わる前にぶつかるようになっていたため修正しました。

before
<img width="1395" height="1099" alt="image" src="https://github.com/user-attachments/assets/025214c8-c305-4af3-b97e-cb90649dfde6" />
after
<img width="1395" height="1099" alt="image" src="https://github.com/user-attachments/assets/8bc40eeb-cb7d-4162-afd5-e90573e97785" />
