### PR TITLE
[9/1 の本番リリース前に実施] noindex を削除

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -45,9 +45,6 @@
   <meta name="description"         content="{{ site.description | strip_html | escape }}" />
   {% endif %}
 
-  <!-- リリースまで検索エンジンのインデックスから除外する -->
-  <meta name="robots" content="noindex">
-
   <!-- Google Analytics -------------------------- -->
   {% if jekyll.environment == 'production' %}
   {% include google-analytics.html %}


### PR DESCRIPTION
## 概要
- 検索エンジンにインデックスしてもらうため、noindex を削除