### PR TITLE
セッションとワークショップのブロックをカミングスーン表示にする

### DIFF
--- a/_includes/top/sections/session.html
+++ b/_includes/top/sections/session.html
@@ -1,4 +1,4 @@
-<div id="session" class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto pt-28 -mt-28 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
+{% comment %} <div id="session" class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto pt-28 -mt-28 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
   <div class="w-full lg:w-2/5 mb-8 lg:mt-68">
     <div class="lg:max-w-sm lg:place-self-end lg:mr-[10%]">
       <h2 class="text-4xl mb-4 text-center lg:text-left">
@@ -24,4 +24,23 @@
     </li>
     {% endfor %}
   </ul>
+</div> {% endcomment %}
+
+<div id="session" class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto pt-28 -mt-28 mb-16 flex flex-col lg:-mt-64 lg:flex-row items-center lg:items-start">
+  <div class="w-full lg:w-2/5 mb-8 lg:mt-55">
+    <div class="lg:max-w-sm lg:place-self-end lg:mr-[10%]">
+      <h2 class="text-4xl mb-4 text-center lg:text-left">
+        セッション
+        <span class="block mt-2 text-2xl">SESSION</span>
+      </h2>
+      <p class="leading-7 mb-10">
+        さまざまな分野で活やくしている人たちの話を聞いて、考え方やアイデアを広げてみよう。<br />
+        プログラミングや教育、地域での活動など、たくさんのヒントがつまった時間です。
+      </p>
+    </div>
+  </div>
+
+  <div class="lg:mt-50 mt-0 flex item-center justify-center h-[150px] lg:h-[300px] w-full lg:w-3/5">
+    <p class="size-full lg:text-7xl text-2xl text-gray-500 opacity-50 text-center flex items-center justify-center">Coming soon...</p>
+  </div>
 </div>

--- a/_includes/top/sections/workshop.html
+++ b/_includes/top/sections/workshop.html
@@ -1,4 +1,4 @@
-<div
+{% comment %} <div
   class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto mt-20 lg:mt-48 mb-16 flex flex-col lg:flex-row-reverse items-center lg:items-start">
   <div class="w-full lg:w-2/5 mb-8">
     <div class="lg:max-w-sm lg:place-self-start lg:ml-[10%]">
@@ -25,4 +25,24 @@
     </li>
     {% endfor %}
   </ul>
+</div> {% endcomment %}
+
+<div
+  class="max-w-3xl lg:max-w-[1800px] px-8 mx-auto mb-16 flex flex-col lg:flex-row-reverse items-center lg:items-start">
+  <div class="w-full lg:w-2/5 mb-8 lg:mt-15">
+    <div class="lg:max-w-sm lg:place-self-start lg:ml-[10%]">
+      <h2 class="text-4xl mb-4 text-center lg:text-left">
+        ワークショップ
+        <span class="block mt-2 text-2xl">WORKSHOP</span>
+      </h2>
+      <p class="leading-7 mb-10">
+        実際にプログラミングやものづくりを体験できるコーナーです。<br />
+        気になっていたことにチャレンジしたり、新しい道具や考え方にふれるチャンス！
+      </p>
+    </div>
+  </div>
+
+  <div class=" flex item-center justify-center h-[150px] lg:h-[300px] w-full lg:w-3/5">
+    <p class="size-full lg:text-7xl text-2xl text-gray-500 opacity-50 text-center flex items-center justify-center">Coming soon...</p>
+  </div>
 </div>


### PR DESCRIPTION
掲題のとおりです。
掲載内容がないため、一旦セッションとワークショップの項目をComing soonの表示にします
<img width="1406" height="804" alt="image" src="https://github.com/user-attachments/assets/3de42e4a-529d-4111-b190-c048a4f4f596" />
<img width="363" height="563" alt="image" src="https://github.com/user-attachments/assets/ea94373a-9e36-4598-87fb-f12471677418" />
