### PR TITLE
jekyll のビルドから除外するファイルを調整

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,14 +56,10 @@ defaults:
 # their entries' file path in the `include:` list.
 #
 exclude:
-  - .sass-cache/
-  - .jekyll-cache/
-  - gemfiles/
-  - Gemfile
-  - Gemfile.lock
-  - node_modules/
-  - tasks/
-  - vendor/bundle/
-  - vendor/cache/
-  - vendor/gems/
-  - vendor/ruby/
+  - CNAME
+  - docker-compose.yml
+  - Dockerfile
+  - LICENSE.md
+  - Rakefile
+  - README.md
+  - test-directory-structure.py


### PR DESCRIPTION
_config.yml の exclude を空にしてビルドした際に _site に含まれるファイル

- 404.html
- assets/
- browserconfig.xml
- CNAME
- code-of-conduct/
- css/
- docker-compose.yml
- Dockerfile
- events/
- feed.xml
- img/
- index.html
- LICENSE.md
- privacy/
- Rakefile
- README.md
- robots.txt
- security.txt
- site.webmanifest
- sitemap.xml
- test-directory-structure.py
