### PR TITLE
当日スタッフ募集ページの表示内容修正

### DIFF
--- a/_posts/2025-08-30-staff.md
+++ b/_posts/2025-08-30-staff.md
@@ -18,41 +18,54 @@ permalink: /staff/
 
 <h3>当日お手伝いしてくださる方を募集します</h3>
 
-<p>DojoCon Japan 2025のお手伝いをしたい！という方はおられませんか？</p>
+<p class="leading-6">
+  DojoCon Japan 2025のお手伝いをしたい！という方はおられませんか？<br>
+  DojoCon Japan 2025実行委員会では次のような方のご参加をお待ちしております。
+</p>
 
-<p>DojoCon Japan 2025実行委員会では次のような方のご参加をお待ちしております。</p>
-<ul>
-  <li>CoderDojo の活動に興味のある方</li>
-  <li>参加しているニンジャの保護者の方</li>
-  <li>プログラミングが大好きな子どもたちをサポートしたい方</li>
-</ul>
+<div class="my-4">
+  <ul class="leading-6">
+    <li>CoderDojo の活動に興味のある方</li>
+    <li>参加しているニンジャの保護者の方</li>
+    <li>プログラミングが大好きな子どもたちをサポートしたい方</li>
+  </ul>
+</div>
 
-<p>皆様のご応募をお待ちしております。</p>
-
-<p>聴きたいセッションや参加したい企画・ワークショップがあるなど、時間を調整いたしますのでお気軽にご相談ください。</p>
+<p class="leading-6">
+  聴きたいセッションや参加したい企画・ワークショップがあるなど、時間を調整いたしますのでお気軽にご相談ください。<br>
+  皆様のご応募をお待ちしております。
+</p>
 
 <h4 id="当日スタッフの仕事">当日スタッフの仕事</h4>
-<ul>
-  <li>当日準備</li>
-  <li>受付</li>
-  <li>会場案内</li>
-  <li>セッションサポート</li>
-  <li>チャンピオン相談会のサポート</li>
-  <li>ワークショップのサポート</li>
-  <li>撮影、記録</li>
-  <li>後片付け</li>
-  <li>その他必要な作業</li>
-</ul>
+
+<div>
+  <ul class="leading-6">
+    <li>当日準備</li>
+    <li>受付</li>
+    <li>会場案内</li>
+    <li>セッションサポート</li>
+    <li>チャンピオン相談会のサポート</li>
+    <li>ワークショップのサポート</li>
+    <li>撮影、記録</li>
+    <li>後片付け</li>
+    <li>その他必要な作業</li>
+  </ul>
+</div>
+
 <h3 id="参加条件">参加条件</h3>
-<ul>
-  <li>Discordでやり取りができること</li>
-  <li>CoderDojoの活動にご賛同いただけること</li>
-  <li><a href="/code-of-conduct/" target="_blank">行動規範</a>に同意いただけること</li>
-  <li>未成年者の場合は、保護者の同意を得ていること</li>
-</ul>
+
+<div>
+  <ul class="leading-6">
+    <li>Discordでやり取りができること</li>
+    <li>CoderDojoの活動にご賛同いただけること</li>
+    <li><a href="/code-of-conduct/" target="_blank">行動規範</a>に同意いただけること</li>
+    <li>未成年者の場合は、保護者の同意を得ていること</li>
+  </ul>
+</div>
 
 <h3 id="開催日会場">開催日・会場</h3>
-<p>
+
+<div>
   <table style="word-break: keep-all;">
     <tr>
       <td>開催日</td>
@@ -67,22 +80,27 @@ permalink: /staff/
       </td>
     </tr>
   </table>
-</p>
+</div>
 
 <h3 id="当日スタッフ応募">当日スタッフ応募</h3>
-<p>応募は以下のフォームよりご連絡ください。</p>
 
-<a href="https://forms.gle/Gd3zqTbcDix8nDuK7" target="_blank">応募フォーム</a>
+<p class="leading-6">
+  応募は以下のフォームよりご連絡ください。<br>
+  <a href="https://forms.gle/Gd3zqTbcDix8nDuK7" target="_blank">応募フォーム</a>
+</p>
 
 <h3 id="過去のdojocon-japan">過去のDojoCon Japan</h3>
-<ul>
-  <li><a href="https://dojocon2024.coderdojo.jp/">DojoCon Japan 2024</a></li>
-  <li><a href="https://dojocon2023.coderdojo.jp/">DojoCon Japan 2023</a></li>
-  <li><a href="https://dojocon2022.coderdojo.jp/">DojoCon Japan 2022</a></li>
-  <li><a href="https://dojocon2021.coderdojo.jp/">DojoCon Japan 2021</a></li>
-  <li><a href="https://dojocon2020.coderdojo.jp/">DojoCon Japan 2020</a></li>
-  <li><a href="https://dojocon2019.coderdojo.jp/">DojoCon Japan 2019</a></li>
-  <li><a href="https://dojocon2018.coderdojo.jp/">DojoCon Japan 2018</a></li>
-  <li><a href="https://dojocon2017.coderdojo.jp/">DojoCon Japan 2017</a></li>
-  <li><a href="https://dojocon2016.coderdojo.jp/">DojoCon Japan 2016</a></li>
-</ul>
+
+<div>
+  <ul class="leading-6">
+    <li><a href="https://dojocon2024.coderdojo.jp/">DojoCon Japan 2024</a></li>
+    <li><a href="https://dojocon2023.coderdojo.jp/">DojoCon Japan 2023</a></li>
+    <li><a href="https://dojocon2022.coderdojo.jp/">DojoCon Japan 2022</a></li>
+    <li><a href="https://dojocon2021.coderdojo.jp/">DojoCon Japan 2021</a></li>
+    <li><a href="https://dojocon2020.coderdojo.jp/">DojoCon Japan 2020</a></li>
+    <li><a href="https://dojocon2019.coderdojo.jp/">DojoCon Japan 2019</a></li>
+    <li><a href="https://dojocon2018.coderdojo.jp/">DojoCon Japan 2018</a></li>
+    <li><a href="https://dojocon2017.coderdojo.jp/">DojoCon Japan 2017</a></li>
+    <li><a href="https://dojocon2016.coderdojo.jp/">DojoCon Japan 2016</a></li>
+  </ul>
+</div>

--- a/_posts/2025-08-30-staff.md
+++ b/_posts/2025-08-30-staff.md
@@ -66,17 +66,17 @@ permalink: /staff/
 <h3 id="開催日会場">開催日・会場</h3>
 
 <div>
-  <table style="word-break: keep-all;">
+  <table class="border-separate border-spacing-x-1 sm:border-spacing-x-4 break-keep wrap-anywhere">
     <tr>
-      <td>開催日</td>
+      <td class="whitespace-nowrap">開催日</td>
       <td>2025年10月25日（土）</td>
     </tr>
     <tr>
-      <td class="align-top">会場</td>
+      <td class="whitespace-nowrap align-top">会場</td>
       <td>
-        <span class="whitespace-nowrap">久留米シティプラザ</span><wbr>
-        <span class="whitespace-nowrap">（福岡県久留米市六ツ門町８−１）</span><wbr>
-        （<a href="{{ site.map }}" target="_blank" class="whitespace-nowrap">Google Maps</a>）
+        久留米シティプラザ<wbr>
+        （福岡県久留米市六ツ門町８−１）<wbr>
+        （<a href="{{ site.map }}" target="_blank">Google Maps</a>）
       </td>
     </tr>
   </table>

--- a/_posts/2025-08-30-staff.md
+++ b/_posts/2025-08-30-staff.md
@@ -76,13 +76,13 @@ permalink: /staff/
 
 <h3 id="過去のdojocon-japan">過去のDojoCon Japan</h3>
 <ul>
-  <li><a href="https://dojocon2024.coderdojo.jp/">DojoCon Japan2024</a></li>
-  <li><a href="https://dojocon2023.coderdojo.jp/">DojoCon Japan2023</a></li>
-  <li><a href="https://dojocon2022.coderdojo.jp/">DojoCon Japan2022</a></li>
-  <li><a href="https://dojocon2021.coderdojo.jp/">DojoCon Japan2021</a></li>
-  <li><a href="https://dojocon2020.coderdojo.jp/">DojoCon Japan2020</a></li>
-  <li><a href="https://dojocon2019.coderdojo.jp/">DojoCon Japan2019</a></li>
-  <li><a href="https://dojocon2018.coderdojo.jp/">DojoCon Japan2018</a></li>
-  <li><a href="https://dojocon2017.coderdojo.jp/">DojoCon Japan2017</a></li>
-  <li><a href="https://dojocon2016.coderdojo.jp/">DojoCon Japan2016</a></li>
+  <li><a href="https://dojocon2024.coderdojo.jp/">DojoCon Japan 2024</a></li>
+  <li><a href="https://dojocon2023.coderdojo.jp/">DojoCon Japan 2023</a></li>
+  <li><a href="https://dojocon2022.coderdojo.jp/">DojoCon Japan 2022</a></li>
+  <li><a href="https://dojocon2021.coderdojo.jp/">DojoCon Japan 2021</a></li>
+  <li><a href="https://dojocon2020.coderdojo.jp/">DojoCon Japan 2020</a></li>
+  <li><a href="https://dojocon2019.coderdojo.jp/">DojoCon Japan 2019</a></li>
+  <li><a href="https://dojocon2018.coderdojo.jp/">DojoCon Japan 2018</a></li>
+  <li><a href="https://dojocon2017.coderdojo.jp/">DojoCon Japan 2017</a></li>
+  <li><a href="https://dojocon2016.coderdojo.jp/">DojoCon Japan 2016</a></li>
 </ul>

--- a/_posts/2025-08-30-staff.md
+++ b/_posts/2025-08-30-staff.md
@@ -8,24 +8,30 @@ tags: 当日スタッフ
 permalink: /staff/
 ---
 
-<h1>当日お手伝いしてくださる方を募集します</h1>
+<style>
+  @media (max-width: 640px) {
+    h2 {
+      font-size: 2em;
+    }
+  }
+</style>
 
-<h2>DojoCon Japan 2025の当日スタッフを募集します！</h2>
+<h3>当日お手伝いしてくださる方を募集します</h3>
 
 <p>DojoCon Japan 2025のお手伝いをしたい！という方はおられませんか？</p>
 
-<p>DojoCon Japan 2025実行委員会ではこのような方のご参加をお待ちしております。</p>
+<p>DojoCon Japan 2025実行委員会では次のような方のご参加をお待ちしております。</p>
 <ul>
   <li>CoderDojo の活動に興味のある方</li>
   <li>参加しているニンジャの保護者の方</li>
   <li>プログラミングが大好きな子どもたちをサポートしたい方</li>
 </ul>
 
-<p>皆様のご参加をお待ちしております。</p>
+<p>皆様のご応募をお待ちしております。</p>
 
 <p>聴きたいセッションや参加したい企画・ワークショップがあるなど、時間を調整いたしますのでお気軽にご相談ください。</p>
 
-<h2 id="当日スタッフの仕事">当日スタッフの仕事</h2>
+<h4 id="当日スタッフの仕事">当日スタッフの仕事</h4>
 <ul>
   <li>当日準備</li>
   <li>受付</li>
@@ -37,14 +43,15 @@ permalink: /staff/
   <li>後片付け</li>
   <li>その他必要な作業</li>
 </ul>
-<h2 id="参加条件">参加条件</h2>
+<h3 id="参加条件">参加条件</h3>
 <ul>
   <li>Discordでやり取りができること</li>
-  <li>CoderDojoの活動にご賛同いただけること、<a href="/code-of-conduct/" target="_blank">行動規範</a>に同意いただけること</li>
-  <li>未成年者の方は、保護者の同意が必要です</li>
+  <li>CoderDojoの活動にご賛同いただけること</li>
+  <li><a href="/code-of-conduct/" target="_blank">行動規範</a>に同意いただけること</li>
+  <li>未成年者の場合は、保護者の同意を得ていること</li>
 </ul>
 
-<h2 id="開催日会場">開催日・会場</h2>
+<h3 id="開催日会場">開催日・会場</h3>
 <p>
   <table style="word-break: keep-all;">
     <tr>
@@ -52,30 +59,30 @@ permalink: /staff/
       <td>2025年10月25日（土）</td>
     </tr>
     <tr>
-      <td>会場</td>
+      <td class="align-top">会場</td>
       <td>
-        久留米シティプラザ<wbr>
-        （福岡県久留米市六ツ門町８−１）<wbr>
-        （<a href="{{ site.map }}" target="_blank" style="white-space: nowrap">Google Maps</a>）
+        <span class="whitespace-nowrap">久留米シティプラザ</span><wbr>
+        <span class="whitespace-nowrap">（福岡県久留米市六ツ門町８−１）</span><wbr>
+        （<a href="{{ site.map }}" target="_blank" class="whitespace-nowrap">Google Maps</a>）
       </td>
     </tr>
   </table>
 </p>
 
-<h2 id="当日スタッフ応募">当日スタッフ応募</h2>
+<h3 id="当日スタッフ応募">当日スタッフ応募</h3>
 <p>応募は以下のフォームよりご連絡ください。</p>
 
 <a href="https://forms.gle/Gd3zqTbcDix8nDuK7" target="_blank">応募フォーム</a>
 
-<h2 id="過去のdojocon-japan">過去のDojoCon Japan</h2>
+<h3 id="過去のdojocon-japan">過去のDojoCon Japan</h3>
 <ul>
-  <li><a href="https://dojocon2024.coderdojo.jp/">https://dojocon2024.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2023.coderdojo.jp/">https://dojocon2023.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2022.coderdojo.jp/">https://dojocon2022.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2021.coderdojo.jp/">https://dojocon2021.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2020.coderdojo.jp/">https://dojocon2020.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2019.coderdojo.jp/">https://dojocon2019.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2018.coderdojo.jp/">https://dojocon2018.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2017.coderdojo.jp/">https://dojocon2017.coderdojo.jp/</a></li>
-  <li><a href="https://dojocon2016.coderdojo.jp/">https://dojocon2016.coderdojo.jp/</a></li>
+  <li><a href="https://dojocon2024.coderdojo.jp/">DojoCon Japan2024</a></li>
+  <li><a href="https://dojocon2023.coderdojo.jp/">DojoCon Japan2023</a></li>
+  <li><a href="https://dojocon2022.coderdojo.jp/">DojoCon Japan2022</a></li>
+  <li><a href="https://dojocon2021.coderdojo.jp/">DojoCon Japan2021</a></li>
+  <li><a href="https://dojocon2020.coderdojo.jp/">DojoCon Japan2020</a></li>
+  <li><a href="https://dojocon2019.coderdojo.jp/">DojoCon Japan2019</a></li>
+  <li><a href="https://dojocon2018.coderdojo.jp/">DojoCon Japan2018</a></li>
+  <li><a href="https://dojocon2017.coderdojo.jp/">DojoCon Japan2017</a></li>
+  <li><a href="https://dojocon2016.coderdojo.jp/">DojoCon Japan2016</a></li>
 </ul>


### PR DESCRIPTION
## summary
* 段組み修正(タイトルがh2で描画されていたので、以下のhタグを3からにしました)
* 文言修正
  * https://discord.com/channels/1355061393992323192/1366040707902472244/1411037846608941198
* タイトルのサイズをSPで改行が出ないように微調整
* 過去DojoConのリンク表示を短くする

