### PR TITLE
8/30とかいた記事の公開日を9/1に変更、未来の記事をビルド結果に含められるようにする

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 # You can create any custom variable you would like,
 # and they will be accessible like {{ site.your_variable }}.
 
+future: true
 timezone: Asia/Tokyo
 year: 2025
 title: DojoCon Japan

--- a/_posts/2025-09-01-registration.md
+++ b/_posts/2025-09-01-registration.md
@@ -2,7 +2,7 @@
 layout: post
 title: 参加受付を開始しました
 title-in-news-list: DojoCon Japan 2025 一般参加の受付を開始しました
-date: 2025-08-30T00:00:00 UTC+09:00
+date: 2025-09-01T00:00:00 UTC+09:00
 categories: news
 tag: 参加受付
 permalink: /registration/

--- a/_posts/2025-09-01-staff.md
+++ b/_posts/2025-09-01-staff.md
@@ -2,7 +2,7 @@
 layout: post
 title: 当日スタッフ募集
 title-in-news-list: DojoCon Japan 2025 の当日スタッフを募集します
-date: 2025-08-30T00:00:00 UTC+09:00
+date: 2025-09-01T00:00:00 UTC+09:00
 categories: news
 tags: 当日スタッフ
 permalink: /staff/


### PR DESCRIPTION
掲題のとおりです
これ以降、未来の日付の記事が公開できるようになります
