### PR TITLE
記事ページにある見出しのレイアウトを修正

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 {% include navbar.html %}
 
-<h2 class="max-w-4xl mx-auto text-4xl text-center mb-2 mt-30 px-8 xl:mt-15">
+<h2 class="mx-auto text-4xl text-center mb-2 mt-30 px-4 sm:px-8 xl:mt-15">
   {{ page.title }}
   <span class="block mt-5 text-2xl">{{ page.subtitle | upcase }}</span>
 </h2>


### PR DESCRIPTION
- 最大幅を削除
- 左右方向の余白を調整
  - スマホサイズの場合は、更に小さい余白（本文と同じ余白）を確保するように