### PR TITLE
Change CNAME: `dojocon2025-test` -> `dojocon2025.coderdojo.jp`

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-dojocon2025-test.coderdojo.jp
+dojocon2025.coderdojo.jp


### PR DESCRIPTION
This CNAME has been set up along with DNS:

<img width="405" height="152" alt="image" src="https://github.com/user-attachments/assets/29aef19b-2fba-4458-9e12-bed218aafda4" />

From now `dojocon2025-test.coderdojo.jp` subdomain no longer work. Instead, see https://dojocon2025.coderdojo.jp/ as this repo's production environment. 🚀 ✨ 
