### PR TITLE
Add missing alt attributes for images to make CI pass

### DIFF
--- a/_includes/top/sections/about-coderdojo.html
+++ b/_includes/top/sections/about-coderdojo.html
@@ -10,7 +10,7 @@
       <!-- モバイルの場合 -->
       <h2 class="relative xl:hidden max-w-lg">
         <img src="/img/top/about-coderdojo/about-coderdojo-heading.webp" alt="About CoderDojo" />
-        <img class="h-full w-auto absolute right-0 top-0 w-3xs" src="/img/top/about-coderdojo/coderdojo-logo-transparent.webp" />
+        <img class="h-full w-auto absolute right-0 top-0 w-3xs" src="/img/top/about-coderdojo/coderdojo-logo-transparent.webp" alt="CoderDojo ロゴ画像" />
       </h2>
 
       <!-- 説明文セクション -->
@@ -29,12 +29,12 @@
   <!-- DojoCon の画像 -->
   <!-- デスクトップの場合 -->
   <div class="hidden xl:flex items-center -mx-4 xl:mt-18 justify-between">
-    <div class="w-2/7 mt-12"><img class="w-full" src="/img/top/about-coderdojo/coderdojo-logo-transparent.webp" /></div>
-    <div class="w-2/3 mt-12"><img class="w-full" src="/img/top/about-coderdojo/dojocon.webp" /></div>
+    <div class="w-2/7 mt-12"><img class="w-full" src="/img/top/about-coderdojo/coderdojo-logo-transparent.webp" alt="CoderDojo ロゴ画像" /></div>
+    <div class="w-2/3 mt-12"><img class="w-full" src="/img/top/about-coderdojo/dojocon.webp" alt="DojoCon Japan 2019 @ 名古屋の様子" /></div>
   </div>
 
   <!-- モバイルの場合 -->
   <div class="xl:hidden block m-8">
-    <img class="max-w-3xl place-self-center w-full" src="/img/top/about-coderdojo/dojocon.webp" />
+    <img class="max-w-3xl place-self-center w-full" src="/img/top/about-coderdojo/dojocon.webp" alt="DojoCon Japan 2019 @ 名古屋の様子" />
   </div>
 </div>

--- a/_includes/top/sections/inspire-next.html
+++ b/_includes/top/sections/inspire-next.html
@@ -23,9 +23,9 @@
       <!-- 写真にかぶっても視認性を確保するためのオーバーレイ -->
       <div class="bg-linear-to-r from-transparent from-70% to-white hidden top-0 xl:block absolute size-full">
       </div>
-      <img class="w-full" src="/img/top/inspire-next/exhibit.webp" />
+      <img class="w-full" src="/img/top/inspire-next/exhibit.webp" alt="展示会の様子" />
     </div>
-    <div class="w-1/4 -mt-48"><img class="w-full" src="/img/top/inspire-next/fire-transparent.webp" /></div>
+    <div class="w-1/4 -mt-48"><img class="w-full" src="/img/top/inspire-next/fire-transparent.webp" alt="「好奇心に火をつけよう」の背景透過画像" /></div>
   </div>
 </div>
 
@@ -34,7 +34,7 @@
   <div class="max-w-3xl mx-auto">
     <h2 class="relative max-w-7xl">
       <img src="/img/top/inspire-next/inspire-next-heading.webp" alt="Inspire Next ～好奇心に火をつけよう～" />
-      <img class="h-[140%] w-auto absolute right-0 -bottom-1/5 w-3xs" src="/img/top/inspire-next/fire-transparent.webp" />
+      <img class="h-[140%] w-auto absolute right-0 -bottom-1/5 w-3xs" src="/img/top/inspire-next/fire-transparent.webp" alt="「好奇心に火をつけよう」の背景透過画像" />
     </h2>
 
     <div class="mt-9 leading-7">
@@ -52,6 +52,6 @@
   </div>
 
   <div class="max-w-3xl mx-auto mt-8">
-    <img class="place-self-center w-full" src="/img/top/inspire-next/exhibit.webp" />
+    <img class="place-self-center w-full" src="/img/top/inspire-next/exhibit.webp" alt="展示会の様子" />
   </div>
 </div>

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -36,7 +36,7 @@ title: 企画
       {% endif %}
 
       <div class="flex gap-x-4 mt-8">
-        <img src="{{ event.img }}" />
+        <img src="{{ event.img }}" alt="{{ event.title | escape }}" />
       </div>
     </li>
   {% endfor %}

--- a/_posts/2025-08-28-keynote1.md
+++ b/_posts/2025-08-28-keynote1.md
@@ -12,7 +12,7 @@ CoderDojo Japan 理事<br />
 広島大学大学院 特命助教
 
 <div class="flex max-w-100 mx-auto my-4 justify-center">
-  <img class="w-full" src="/img/sessions/profile/miyajima-kirie.webp">
+  <img class="w-full" src="/img/sessions/profile/miyajima-kirie.webp" alt="宮島 衣瑛">
 </div>
 
 ## 登壇者紹介

--- a/_posts/2025-08-28-keynote2.md
+++ b/_posts/2025-08-28-keynote2.md
@@ -12,7 +12,7 @@ permalink: /sessions/keynote2/
 国立大学法人 東京学芸大学大学院教育学研究科教授
 
 <div class="flex max-w-100 mx-auto my-4 justify-center">
-  <img class="w-full" src="/img/sessions/profile/komiyama-rieko.webp">
+  <img class="w-full" src="/img/sessions/profile/komiyama-rieko.webp" alt="小宮山 利恵子">>
 </div>
 
 ## 登壇者紹介

--- a/index.md
+++ b/index.md
@@ -18,13 +18,13 @@ layout: top
 {% include top/sections/news.html %}
 
 <div class="-mx-4">
-  <img class="w-full" src="/img/top/background1.webp" />
+  <img class="w-full" src="/img/top/background1.webp" alt="DojoCon Japan 2023 @ 奈良の様子" />
 </div>
 
 {% include top/sections/keynote.html %}
 
 <div class="-mx-4">
-  <img class="w-full" src="/img/top/background2.webp" />
+  <img class="w-full" src="/img/top/background2.webp" alt="micro:bit でLチカしている様子" />
 </div>
 
 {% include top/sections/session.html %}
@@ -32,19 +32,19 @@ layout: top
 {% include top/sections/workshop.html %}
 
 <div class="-mx-4">
-  <img class="w-full" src="/img/top/background3.webp" />
+  <img class="w-full" src="/img/top/background3.webp" alt="鉄道模型を動かしている様子"/>
 </div>
 
 {% include top/sections/sponsor.html %}
 
 <div class="-mx-4">
-  <img class="w-full" src="/img/top/background4.webp" />
+  <img class="w-full" src="/img/top/background4.webp" alt="Why CoderDojo Wall - 教えて！みんなが CoderDojo に参加する理由" />
 </div>
 
 {% include top/sections/contact.html %}
 
 <div class="-mx-4">
-  <img class="w-full" src="/img/top/background5.webp" />
+  <img class="w-full" src="/img/top/background5.webp" alt="DojoCon Japan 2019 @ 名古屋の様子" />
 </div>
 
 {% include top/sections/organized-by.html %}


### PR DESCRIPTION
生成された HTML の静的解析テスト (`$ bundle exec rake test`) を実行し、出てきたエラーを修正しました! 🛠💨✨

## Before 

※ クリックするとテスト結果レポートの詳細が表示されます。
<details>
  <summary><strong>$ bundle exec rake test</strong></summary>

```console
$ bundle exec rake test

...


Incremental build: disabled. Enable with --incremental
      Generating...
       Jekyll Feed: Generating feed for posts
                    done in 0.174 seconds.

Auto-regeneration: disabled. Use --watch to enable.
Running 5 checks (Favicon, Images, Links, OpenGraph, Scripts) in ["_site"] on *.html files ...


Checking 21 internal links
Checking internal link hashes in 1 file
Ran on 18 files!


For the Images check, the following failures were found:

* At _site/events/index.html:168:

  image /img/events/saikyo-coderdojo.webp does not have an alt attribute

* At _site/events/index.html:197:

  image /img/contests/cover.webp does not have an alt attribute

* At _site/index.html:201:

  image /img/top/about-coderdojo/coderdojo-logo-transparent.webp does not have an alt attribute

* At _site/index.html:220:

  image /img/top/about-coderdojo/coderdojo-logo-transparent.webp does not have an alt attribute

* At _site/index.html:221:

  image /img/top/about-coderdojo/dojocon.webp does not have an alt attribute

* At _site/index.html:226:

  image /img/top/about-coderdojo/dojocon.webp does not have an alt attribute

* At _site/index.html:255:

  image /img/top/inspire-next/exhibit.webp does not have an alt attribute

* At _site/index.html:257:

  image /img/top/inspire-next/fire-transparent.webp does not have an alt attribute

* At _site/index.html:266:

  image /img/top/inspire-next/fire-transparent.webp does not have an alt attribute

* At _site/index.html:284:

  image /img/top/inspire-next/exhibit.webp does not have an alt attribute

* At _site/index.html:360:

  image /img/top/background1.webp does not have an alt attribute

* At _site/index.html:429:

  image /img/top/background2.webp does not have an alt attribute

* At _site/index.html:471:

  image /img/top/background3.webp does not have an alt attribute

* At _site/index.html:603:

  image /img/top/background4.webp does not have an alt attribute

* At _site/index.html:619:

  image /img/top/background5.webp does not have an alt attribute

* At _site/sessions/keynote1/index.html:154:

  image /img/sessions/profile/miyajima-kirie.webp does not have an alt attribute

* At _site/sessions/keynote2/index.html:154:

  image /img/sessions/profile/komiyama-rieko.webp does not have an alt attribute


HTML-Proofer found 17 failures!
```

</details>


## After

```console
$ bundle exec rake test

...

Incremental build: disabled. Enable with --incremental
      Generating...
       Jekyll Feed: Generating feed for posts
                    done in 0.172 seconds.

Auto-regeneration: disabled. Use --watch to enable.
Running 5 checks (Favicon, Images, Links, OpenGraph, Scripts) in ["_site"] on *.html files ...

Checking 21 internal links
Checking internal link hashes in 1 file
Ran on 18 files!

HTML-Proofer finished successfully.
```

## TIPS

`.github/workflows/test.yml` にある以下のコメントアウトを解除すると、CI 上で自動的に検知できるようになります。ただ今回のように不定期に手動で実行して、結果を確認しても良さそうです 💭

```
    - name: 🔧 Build & Test
      run: |
        ...
        # SKIP_BUILD=true       bundle exec rake test
        # NOTE: サイトが仕上がったら、上記テストを走らせると自動検知できる。
        #       ただ初期は自動検知の通知が多すぎるので手動で実行するのが吉。
        ...
```