### PR TITLE
タイムテーブルを表示できるようにする

### DIFF
--- a/_data/time_table.yml
+++ b/_data/time_table.yml
@@ -1,0 +1,127 @@
+slot_minutes: 10
+
+rooms:
+  - 大会議室（セッション）
+  - 展示（コンテスト用）
+  - 展示
+  - 中会議室（WS１ 電子工作）
+  - 中会議室（WS２）LTブース
+  - 中会議室（WS３ ）
+  - 中会議室（WS４）
+
+room_styles:
+  大会議室（セッション）:         { color: "#c43b3b" }
+  展示（コンテスト用）:           { color: "#f5a201" }
+  展示:                           { color: "#888888" }
+  中会議室（WS１ 電子工作）:      { color: "#2e7d32" }
+  中会議室（WS２）LTブース:       { color: "#1976d2" }
+  中会議室（WS３ ）:              { color: "#7b1fa2" }
+  中会議室（WS４）:               { color: "#ef6c00" }
+
+events:
+  # ── 大会議室（セッション）
+  - room: 大会議室（セッション）
+    start: "10:00"
+    end:   "10:10"
+    title: "開会式"
+  - room: 大会議室（セッション）
+    start: "10:10"
+    end:   "10:20"
+    title: "基調講演（宮島さん）"
+  - room: 大会議室（セッション）
+    start: "11:00"
+    end:   "12:00"
+    title: "コンテスト作品発表"
+  - room: 大会議室（セッション）
+    start: "12:00"
+    end:   "12:40"
+    title: "ランチタイム"
+    note: "適宜お昼をお取りください"
+  - room: 大会議室（セッション）
+    start: "12:40"
+    end:   "13:00"
+    title: "みんなのセッション"
+  - room: 大会議室（セッション）
+    start: "13:40"
+    end:   "14:00"
+    title: "九州チャンピオン座談会"
+  - room: 大会議室（セッション）
+    start: "14:20"
+    end:   "14:40"
+    title: "スピーカーセッション_とり子さん（20分）"
+  - room: 大会議室（セッション）
+    start: "14:40"
+    end:   "14:50"
+    title: "伸びるかも予備"
+  - room: 大会議室（セッション）
+    start: "14:50"
+    end:   "15:10"
+    title: "スピーカーセッション_早良区Dojoチャンピオン（20分）"
+  - room: 大会議室（セッション）
+    start: "15:10"
+    end:   "15:20"
+    title: "スポンサーセッション（2件）"
+  - room: 大会議室（セッション）
+    start: "15:20"
+    end:   "15:30"
+    title: "招待講演（小宮山さん）"
+  - room: 大会議室（セッション）
+    start: "16:00"
+    end:   "16:10"
+    title: "コンテスト結果発表"
+  - room: 大会議室（セッション）
+    start: "16:10"
+    end:   "16:20"
+    title: "スポンサーセッション（1件）"
+    note: "該当なしの場合はCoderDojo Japan活動報告"
+  - room: 大会議室（セッション）
+    start: "16:20"
+    end:   "16:30"
+    title: "閉会式"
+
+  # ── 展示
+  - room: 展示（コンテスト用）
+    start: "10:00"
+    end:   "16:00"
+    title: "ファイナリスト作品展示"
+    note: "14:00 投票締切"
+  - room: 展示
+    start: "10:00"
+    end:   "16:00"
+    title: "展示"
+
+  # ── WS1 電子工作（随時受付）
+  - room: 中会議室（WS１ 電子工作）
+    start: "11:00"
+    end:   "16:00"
+    title: "電子工作ワークショップ（随時受付）"
+
+  # ── WS2 LTブース
+  - room: 中会議室（WS２）LTブース
+    start: "11:20"
+    end:   "12:00"
+    title: "Dojo関係者等大人LT（要申込）"
+  - room: 中会議室（WS２）LTブース
+    start: "13:00"
+    end:   "14:00"
+    title: "DojoニンジャLT（要申込）"
+
+  # ── WS3
+  - room: 中会議室（WS３ ）
+    start: "11:00"
+    end:   "12:00"
+    title: "ブレンダー（要申込）"
+  - room: 中会議室（WS３ ）
+    start: "13:00"
+    end:   "14:00"
+    title: "PLAYRISE"
+
+  # ── WS4
+  - room: 中会議室（WS４）
+    start: "11:00"
+    end:   "12:00"
+    title: "PowerPointとプログラミング"
+  - room: 中会議室（WS４）
+    start: "14:10"
+    end:   "15:00"
+    title: "PowerPointとプログラミング"

--- a/_pages/time-table.html
+++ b/_pages/time-table.html
@@ -1,0 +1,149 @@
+---
+layout: default
+permalink: /time-table/
+title: タイムテーブル
+---
+{% include navbar.html %}
+
+{% assign tt = site.data.time_table %}
+{% assign slot = tt.slot_minutes | default: 15 %}
+{% assign rooms = tt.rooms %}
+{% assign room_count = rooms | size %}
+
+{% assign day_start_min = 600 %}
+{% assign day_end_min = 960 %}
+{% assign total_minutes = day_end_min | minus: day_start_min %}
+{% assign slots_count = total_minutes | divided_by: slot %}
+{% assign last_row = slots_count | minus: 1 %}
+
+<section class="max-w-[1200px] mx-auto px-4 sm:px-8 mt-30 xl:mt-15">
+  <h2 class="text-4xl text-center mb-8">
+    Time table
+    <span class="block mt-3 text-2xl">タイムテーブル</span>
+  </h2>
+
+  <div class="ttable-wrap" aria-label="タイムテーブル（横スクロール可）">
+    <table class="ttable" style="--room-count: {{ room_count }};">
+      <caption>
+        {{ tt.date | default: site.date_event }} のタイムテーブル
+      </caption>
+
+      <thead>
+        <tr>
+          <th scope="col" class="ttable__th ttable__th--start">時間</th>
+          {% for r in rooms %}
+            {% assign rstyle = tt.room_styles[r] %}
+            <th scope="col"
+                class="ttable__th ttable__th--room"
+                style="--room-color: {{ rstyle.color | default: '#c43b3b' }};">
+              <span class="ttable__room-cap">{{ r }}</span>
+            </th>
+          {% endfor %}
+        </tr>
+      </thead>
+
+      <tbody>
+        {% for i in (0..last_row) %}
+          {% assign row_min = i | times: slot | plus: day_start_min %}
+          {% assign h = row_min | divided_by: 60 %}
+          {% assign mf = row_min | modulo: 60 | plus: 0 | prepend: '0' | slice: -2, 2 %}
+
+          <tr>
+            <!-- 左1列（sticky） -->
+            <th scope="row" class="ttable__cell ttable__cell--start">{{ h }}:{{ mf }}</th>
+
+            {% for r in rooms %}
+              {% assign rstyle = tt.room_styles[r] %}
+              {% assign events_in_room = tt.events | where: 'room', r | sort: 'start' %}
+
+              {% assign active_event = nil %}
+              {% assign active_event_start_index = nil %}
+
+              {% for ev in events_in_room %}
+                {% assign s_h = ev.start | split: ':' | first | plus: 0 %}
+                {% assign s_m = ev.start | split: ':' | last  | plus: 0 %}
+                {% assign e_h = ev.end   | split: ':' | first | plus: 0 %}
+                {% assign e_m = ev.end   | split: ':' | last  | plus: 0 %}
+                {% assign s_min = s_h | times: 60 | plus: s_m %}
+                {% assign e_min = e_h | times: 60 | plus: e_m %}
+
+                {% assign s_clamped = s_min %}
+                {% if s_clamped < day_start_min %}{% assign s_clamped = day_start_min %}{% endif %}
+                {% assign e_clamped = e_min %}
+                {% if e_clamped > day_end_min %}{% assign e_clamped = day_end_min %}{% endif %}
+
+                {% assign span_minutes = e_clamped | minus: s_clamped %}
+                {% if span_minutes > 0 %}
+                  {% assign numerator = span_minutes | plus: slot | minus: 1 %}
+                  {% assign span_slots = numerator | divided_by: slot %}
+                  {% assign s_index = s_clamped | minus: day_start_min | divided_by: slot %}
+                  {% assign e_index = s_index | plus: span_slots %}
+                  {% if i >= s_index and i < e_index %}
+                    {% assign active_event = ev %}
+                    {% assign active_event_start_index = s_index %}
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+
+              {% if active_event and i == active_event_start_index %}
+                {%- assign s_h = active_event.start | split: ':' | first | plus: 0 -%}
+                {%- assign s_m = active_event.start | split: ':' | last  | plus: 0 -%}
+                {%- assign e_h = active_event.end   | split: ':' | first | plus: 0 -%}
+                {%- assign e_m = active_event.end   | split: ':' | last  | plus: 0 -%}
+                {%- assign s_min = s_h | times: 60 | plus: s_m -%}
+                {%- assign e_min = e_h | times: 60 | plus: e_m -%}
+                {%- if s_min < day_start_min -%}{%- assign s_min = day_start_min -%}{%- endif -%}
+                {%- if e_min > day_end_min -%}{%- assign e_min = day_end_min -%}{%- endif -%}
+                {%- assign span_minutes = e_min | minus: s_min -%}
+                {%- assign numerator = span_minutes | plus: slot | minus: 1 -%}
+                {%- assign span_slots = numerator | divided_by: slot -%}
+                {%- assign accent = active_event.accent | default: rstyle.color -%}
+                <td class="ttable__cell ttable__cell--event" rowspan="{{ span_slots }}" style="--span: {{ span_slots }};">
+                  <div class="ttable__event" style="--accent: {{ accent | default: '#c43b3b' }};">
+                    <div class="ttable__event-time">{{ active_event.start }}–{{ active_event.end }}</div>
+                    <div class="ttable__event-title">{{ active_event.title }}</div>
+                    {% if active_event.subtitle %}
+                      <div class="ttable__event-subtitle">{{ active_event.subtitle }}</div>
+                    {% endif %}
+                    {% if active_event.badge %}
+                      <span class="ttable__badge">{{ active_event.badge }}</span>
+                    {% endif %}
+                  </div>
+                </td>
+              {% elsif active_event == nil %}
+                <td class="ttable__cell ttable__cell--empty" aria-label="空き時間"></td>
+              {% endif %}
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <script>
+    // 重複検知（後勝ち）
+    (function () {
+      const data = {
+        slot: {{ slot | jsonify }},
+        dayStart: {{ day_start_min | jsonify }},
+        dayEnd: {{ day_end_min | jsonify }},
+        rooms: {{ rooms | jsonify }},
+        events: {{ tt.events | jsonify }}
+      };
+      const map = new Map();
+      data.rooms.forEach(r => map.set(r, []));
+      const toMin = t => { const [h,m]=String(t).split(':').map(Number); return h*60+m; };
+      for (const ev of data.events) (map.get(ev.room)||map.set(ev.room,[]).get(ev.room)).push(ev);
+      for (const [room, list] of map) {
+        list.sort((a,b)=>toMin(a.start)-toMin(b.start));
+        for (let i=0;i<list.length-1;i++){
+          const a=list[i], b=list[i+1];
+          const as=Math.max(toMin(a.start), data.dayStart);
+          const ae=Math.min(toMin(a.end),   data.dayEnd);
+          const bs=Math.max(toMin(b.start), data.dayStart);
+          if (ae>bs) console.warn(`[time-table] Overlap in "${room}":`, a, b, '→ later wins');
+        }
+      }
+    })();
+  </script>
+</section>

--- a/_sass/pages/time-table.scss
+++ b/_sass/pages/time-table.scss
@@ -1,0 +1,145 @@
+@use '../global/variables' as *;
+
+@media (max-width: 640px) {
+  :root, body { max-width: 100%; overflow-x: clip; }
+}
+@supports not (overflow-x: clip) {
+  @media (max-width: 640px) { :root, body { overflow-x: hidden; } }
+}
+
+/* ====== スクロール容器 ====== */
+.ttable-wrap{
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  contain: content;
+  scrollbar-gutter: stable both-edges;
+}
+
+/* ====== テーブル ======
+   PCでも「時間は4桁」「会場は全文表示」できるように
+   table-layout: auto と最小幅制約を組み合わせる
+*/
+.ttable{
+  --w-start: 8ch;
+  --room-min: 20rem;
+  --row-h: 56px;
+
+  width: calc(var(--w-start) + var(--room-min) * var(--room-count));
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: auto;
+  background: #fff;
+  border: 1px solid #e6e6e9;
+}
+
+/* ヘッダー */
+.ttable caption{
+  text-align: left;
+  font-weight: 700;
+  padding: 10px 12px;
+}
+.ttable thead th{
+  position: sticky; top: 0; z-index: 3;
+  background: #fafafa;
+  border-bottom: 1px solid #e6e6e9;
+  padding: 10px 12px;
+  font-weight: 800;
+  text-align: left;
+  white-space: nowrap;
+}
+.ttable__th--start{ left: 0; min-width: var(--w-start); }
+.ttable thead th.ttable__th--start{ position: sticky; z-index: 4; }
+
+/* 会場ヘッダーと本文セルの最小幅をそろえる（PCで潰れない） */
+.ttable__th--room{ border-left: 1px solid #ececf1; color:#111; background:
+  linear-gradient(0deg, rgba(255,255,255,0.88), rgba(255,255,255,0.88)), var(--room-color, #c43b3b);
+  min-width: var(--room-min);
+}
+.ttable tbody td{ min-width: var(--room-min); }
+
+/* 行ストライプ & グリッド線 */
+.ttable tbody tr{ height: var(--row-h); }
+.ttable tbody tr:nth-child(odd){ background: #fff; }
+.ttable tbody tr:nth-child(even){ background: #fcfcfe; }
+.ttable tbody tr{
+  background-image: linear-gradient(to right, rgba(0,0,0,0.10) 50%, rgba(0,0,0,0) 0);
+  background-size: 6px 1px;     /* 破線のピッチ/太さ */
+  background-repeat: repeat-x;
+  background-position: left bottom;
+}
+
+/* セル共通 */
+.ttable__cell{
+  padding: 8px 10px;
+  border-right: 1px solid #f0f0f3;
+  vertical-align: top;
+  /* 固定高さを外し、rowspanで正しく縦に伸びるようにする */
+  height: auto;
+  background-clip: padding-box;
+}
+
+/* 左1列（sticky） */
+.ttable__cell--start{
+  position: sticky; z-index: 2; background: #fff; left: 0;
+  min-width: var(--w-start); font-weight: 700; text-align: left;
+}
+/* stickyの左列は行の背景の上に乗るため、
+   横点線が隠れないよう同じ罫線を重ねる */
+.ttable__cell--start{
+  background-image: linear-gradient(to right, rgba(0,0,0,0.10) 50%, rgba(0,0,0,0) 0);
+  background-size: 6px 1px;
+  background-repeat: repeat-x;
+  background-position: left bottom;
+}
+
+/* 空き枠 */
+.ttable__cell--empty{ background: #fff; }
+
+/* イベント：カード化（CEATEC風） */
+.ttable__cell--event{ background: #fff; }
+.ttable__cell--event .ttable__event{ min-height: calc(var(--row-h) * var(--span, 1)); }
+.ttable__event{
+  position: relative;
+  border: 1px solid #e5e6eb;
+  border-radius: 14px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 10px 12px 12px;
+  background: #fff;
+  overflow: hidden;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.ttable__event::before{ content:""; position:absolute; inset:0 0 auto 0; height: 6px; background: var(--accent, #c43b3b); }
+.ttable__event-time{ font-weight: 800; font-size: 1.05rem; letter-spacing: .3px; margin: 8px 0 4px; color: #c43b3b; }
+.ttable__event-title{ font-weight: 800; line-height: 1.35; margin-bottom: 4px; color: #121212; }
+.ttable__event-subtitle{ color: #ee7d05; font-weight: 700; font-size: .92rem; line-height: 1.3; }
+.ttable__badge{ position: absolute; top: 8px; right: 10px; padding: 2px 8px; border-radius: 999px; font-size: .85rem; font-weight: 800; color: #fff; background: var(--accent,#c43b3b); box-shadow: 0 1px 4px rgba(0,0,0,.1); }
+
+/* スマホ微調整 */
+@media (max-width: 640px){
+  .ttable{ --row-h: 54px; --room-min: 16rem; --w-start: 7ch; }
+  .ttable thead th, .ttable__cell{ padding: 8px; font-size: .95rem; }
+  .ttable thead th{ white-space: normal; }
+  .ttable__room-cap{ overflow-wrap: anywhere; word-break: keep-all; }
+  .ttable tbody tr:nth-child(6n){
+    box-shadow: inset 0 -1.5px 0 rgba(0,0,0,0.18);
+  }
+  .ttable-wrap::before, .ttable-wrap::after{
+    content: ""; position: absolute; top: 0; bottom: 0; width: 18px;
+    pointer-events: none; z-index: 6;
+  }
+  .ttable-wrap::before{ left: 0; background: linear-gradient(to right, #fff, rgba(255,255,255,0)); }
+  .ttable-wrap::after{ right: 0; background: linear-gradient(to left, #fff, rgba(255,255,255,0)); }
+  .ttable tbody tr{ background-image: linear-gradient(to right, rgba(0,0,0,0.08) 50%, rgba(0,0,0,0) 0); }
+  .ttable__event-time{ font-size: 1rem; margin-top: 6px; }
+  .ttable__event-title{ font-size: .98rem; }
+  .ttable__event-subtitle{ font-size: .86rem; }
+}
+

--- a/css/main.scss
+++ b/css/main.scss
@@ -8,3 +8,4 @@
 @use 'includes/post';
 
 @use 'components/staff';
+@use 'pages/time-table';


### PR DESCRIPTION
現状は、PCのみのレイアウト調整を行った。スマホのレイアウトを変更しようと思ったが、`中会議室（WS２）LTブース`までしか横がスクロールすることができなく修正することができなかったので保留している。

タイムテーブルのデータは`_data/time_table.yml`に格納してあり、そこを変更すると反映される。

↓PCの画面
<img width="1176" height="548" alt="image" src="https://github.com/user-attachments/assets/472f381d-d77d-4f93-a44a-532898a3c0f2" />
↓スマホの画面
<img width="408" height="700" alt="image" src="https://github.com/user-attachments/assets/6cdac8ec-6cde-4e18-957d-15aaf17a55f4" />
